### PR TITLE
feat: TabNav 컴포넌트

### DIFF
--- a/src/app/(route)/report/analysis/page.tsx
+++ b/src/app/(route)/report/analysis/page.tsx
@@ -1,3 +1,3 @@
 export default function ReportAnalysis() {
-  return <div>리포트 가치관 분석</div>;
+  return <div></div>;
 }

--- a/src/app/(route)/report/layout.module.scss
+++ b/src/app/(route)/report/layout.module.scss
@@ -1,0 +1,58 @@
+.container {
+  background-color: #f7f7f7;
+  height: 100vh;
+}
+
+.characterButton {
+  font-weight: 600;
+  color: #000 !important;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  padding: 2rem 0 1rem 2rem;
+  cursor: pointer;
+}
+
+.characterButtonIcon {
+  color: $neutral-600;
+}
+
+.characterList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 1rem 0;
+}
+
+.characterItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #333;
+  cursor: pointer;
+  padding: 0.5rem 0;
+
+  &:hover {
+    color: #000;
+  }
+}
+
+.checkIcon {
+  color: #007aff; // 파란색 체크 아이콘
+}
+
+.disabled {
+  color: #b0b0b0;
+  opacity: 0.6;
+  cursor: default;
+}
+
+.noAnswer {
+  background: #edeff4;
+  color: #676b75;
+  font-size: 1rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+}

--- a/src/app/(route)/report/layout.tsx
+++ b/src/app/(route)/report/layout.tsx
@@ -57,7 +57,13 @@ export default function ReportLayout({ children }: PropsWithChildren) {
         <TabNav tabs={TABS} />
         {children}
       </FooterLayout>
-      <BottomSheet title="월 선택하기" isOpen={open} height={380} closeSheet={() => setOpen(false)} closeIcon>
+      <BottomSheet
+        title="가치관 캐릭터 선택하기"
+        isOpen={open}
+        height={380}
+        closeSheet={() => setOpen(false)}
+        closeIcon
+      >
         <BottomSheet.Content className={styles.characterList}>
           {characters.map((character) => (
             <div key={character.id} className={styles.characterItem} onClick={() => handleCharacter(character)}>

--- a/src/app/(route)/report/layout.tsx
+++ b/src/app/(route)/report/layout.tsx
@@ -1,12 +1,74 @@
+'use client';
+
 import type { PropsWithChildren } from 'react';
+import { useState } from 'react';
 
 import { FooterLayout } from '@/components/Layout/Footer';
+import { TabNav } from '@/components/TabNav';
+import { BottomSheet } from '@/components/BottomSheet';
+import { ArrowDown2Icon, CheckIcon } from '@/assets/icons';
+import { ROUTES } from '@/constants';
+
+import styles from './layout.module.scss';
+import { TextButton } from '@/components/TextButton';
+
+type Character = {
+  id: number;
+  name: string;
+};
+
+const TABS = [
+  {
+    href: ROUTES.reportAnalysis,
+    label: '캐릭터 분석',
+  },
+  {
+    href: ROUTES.reportQuestions,
+    label: '나의 답변 모아보기',
+  },
+];
+
+const MOCK_CHARACTER1 = {
+  id: 1,
+  name: '첫번째 캐릭터',
+};
+const MOCK_CHARACTER2 = {
+  id: 2,
+  name: '두번째 캐릭터',
+};
+const MOCK_CHARACTERS = [MOCK_CHARACTER1, MOCK_CHARACTER2];
 
 export default function ReportLayout({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false);
+  const [characters, setCharacters] = useState<Character[]>(MOCK_CHARACTERS);
+  const [selectedCharacter, setSelectedCharacter] = useState<Character>(MOCK_CHARACTER1);
+
+  const handleCharacter = (character: Character) => {
+    setSelectedCharacter(character);
+    setOpen(false);
+  };
+
   return (
-    <FooterLayout>
-      {/*<TopBar />*/} {/* 1차 MVP 미포함 */}
-      {children}
-    </FooterLayout>
+    <div className={styles.container}>
+      <FooterLayout>
+        <TextButton className={styles.characterButton} onClick={() => setOpen(true)}>
+          {selectedCharacter.name} <ArrowDown2Icon className={styles.characterButtonIcon} width={24} height={24} />
+        </TextButton>
+        <TabNav tabs={TABS} />
+        {children}
+      </FooterLayout>
+      <BottomSheet title="월 선택하기" isOpen={open} height={380} closeSheet={() => setOpen(false)} closeIcon>
+        <BottomSheet.Content className={styles.characterList}>
+          {characters.map((character) => (
+            <div key={character.id} className={styles.characterItem} onClick={() => handleCharacter(character)}>
+              <span>{character.name}</span>
+              {character.id === selectedCharacter.id && (
+                <CheckIcon className={styles.checkIcon} width={24} height={24} />
+              )}
+            </div>
+          ))}
+        </BottomSheet.Content>
+      </BottomSheet>
+    </div>
   );
 }

--- a/src/app/(route)/report/questions/page.module.scss
+++ b/src/app/(route)/report/questions/page.module.scss
@@ -5,59 +5,6 @@
   text-align: center;
 }
 
-.monthButton {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  width: 100%;
-  padding: 2rem 0;
-  cursor: pointer;
-}
-
-.monthList {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 1rem;
-}
-
-.item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 1rem;
-  font-weight: 500;
-  color: #333;
-  cursor: pointer;
-  padding: 0.5rem 0;
-
-  &:hover {
-    color: #000;
-  }
-}
-
-.checkIcon {
-  color: #007aff; // 파란색 체크 아이콘
-}
-
-.disabled {
-  color: #b0b0b0;
-  opacity: 0.6;
-  cursor: default;
-}
-
-.noAnswer {
-  background: #edeff4;
-  color: #676b75;
-  font-size: 1rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 8px;
-}
-
 .card {
   margin: 0.5rem;
 }

--- a/src/app/(route)/report/questions/page.tsx
+++ b/src/app/(route)/report/questions/page.tsx
@@ -2,11 +2,7 @@
 
 import { useState } from 'react';
 import dayjs from 'dayjs';
-
-import { CheckIcon } from '@/assets/icons';
-import { BottomSheet } from '@/components/BottomSheet';
 import { Card } from '@/components/Card';
-import { TextButton } from '@/components/TextButton';
 
 import styles from './page.module.scss';
 
@@ -22,7 +18,7 @@ type Month = {
   disabled: boolean;
 };
 
-const mockQuestions = Array.from({ length: 10 }, (_, i) => {
+const mockQuestions = Array.from({ length: 1 }, (_, i) => {
   return {
     date: `2025-01-${String(i + 1).padStart(2, '0')}`,
     question: '커리어를 향상시킬 수 있는 일자리이지만 가까운 사람들과 멀어져야한다면, 이 일자리를 선택하실 건가요?',
@@ -32,24 +28,7 @@ const mockQuestions = Array.from({ length: 10 }, (_, i) => {
   };
 });
 
-const month1 = {
-  month: '2025년 3월',
-  disabled: false,
-};
-const month2 = {
-  month: '2025년 2월',
-  disabled: true,
-};
-const month3 = {
-  month: '2025년 1월',
-  disabled: false,
-};
-const mockMonths = [month1, month2, month3];
-
 export default function ReportQuestions() {
-  const [open, setOpen] = useState(false);
-  const [months, setMonths] = useState<Month[]>(mockMonths);
-  const [selectedMonth, setSelectedMonth] = useState<Month>(month1);
   const formatDate = (date: string) => {
     const format = 'M월 D일';
     return dayjs(date).format(format);
@@ -57,33 +36,8 @@ export default function ReportQuestions() {
 
   const [questions, setQuestions] = useState(mockQuestions);
 
-  const handleMonth = (month: Month) => {
-    if (!month.disabled) {
-      setSelectedMonth(month);
-      setOpen(false);
-    }
-  };
-
   return (
     <div className={styles.container}>
-      <TextButton className={styles.monthButton} onClick={() => setOpen(true)}>
-        {selectedMonth.month}
-      </TextButton>
-      <BottomSheet title="월 선택하기" isOpen={open} height={380} closeSheet={() => setOpen(false)} closeIcon>
-        <BottomSheet.Content className={styles.monthList}>
-          {months.map((month) => (
-            <div
-              key={month.month}
-              className={`${styles.item} ${month.disabled ? styles.disabled : ''}`}
-              onClick={() => handleMonth(month)}
-            >
-              <span>{month.month}</span>
-              {month.month === selectedMonth.month && <CheckIcon className={styles.checkIcon} width={24} height={24} />}
-              {month.disabled && <span className={styles.noAnswer}>답변 없음</span>}
-            </div>
-          ))}
-        </BottomSheet.Content>
-      </BottomSheet>
       {questions.map((question, index) => (
         <Card
           key={index}

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -67,6 +67,8 @@
 .trigger {
   border: none;
   background-color: transparent;
+  width: 100%;
+  cursor: pointer;
 }
 
 .icon {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -68,19 +68,19 @@ export default function Card({
     <div className={`${styles.container} ${className}`}>
       <Accordion.Root type="single" collapsible {...(isOpen ? { defaultValue: 'item-1' } : {})}>
         <Accordion.Item value="item-1">
-          <CardComponent className={styles.wrapper}>
-            <Accordion.Header className={styles.header}>
-              <div className={styles.date}>
-                <h4 className={styles.cardSubTitle4}>{date}</h4>
-                <Accordion.Trigger className={styles.trigger}>
+          <Accordion.Trigger className={styles.trigger}>
+            <CardComponent className={styles.wrapper}>
+              <Accordion.Header className={styles.header}>
+                <div className={styles.date}>
+                  <h4 className={styles.cardSubTitle4}>{date}</h4>
                   <ArrowDownIcon width="1.5rem" height="1.5rem" className={styles.icon} />
-                </Accordion.Trigger>
-              </div>
-            </Accordion.Header>
-            <Accordion.Content className={styles.contents}>
-              <CardContents question={question} answer={answer} retrospective={retrospective} />
-            </Accordion.Content>
-          </CardComponent>
+                </div>
+              </Accordion.Header>
+              <Accordion.Content className={styles.contents}>
+                <CardContents question={question} answer={answer} retrospective={retrospective} />
+              </Accordion.Content>
+            </CardComponent>
+          </Accordion.Trigger>
         </Accordion.Item>
       </Accordion.Root>
     </div>

--- a/src/components/TabNav/TabNav.module.scss
+++ b/src/components/TabNav/TabNav.module.scss
@@ -1,0 +1,10 @@
+.container {
+  padding: 0 2rem !important;
+  font-size: 1rem !important;
+  font-weight: 600;
+}
+
+.tab {
+  margin: 1rem 1rem 1rem 0 !important;
+  cursor: pointer !important;
+}

--- a/src/components/TabNav/TabNav.tsx
+++ b/src/components/TabNav/TabNav.tsx
@@ -1,22 +1,31 @@
 import { TabNav } from '@radix-ui/themes';
-import styles from './TabNav.module.scss.module.scss';
+
+import styles from './TabNav.module.scss';
+import cn from 'classnames';
+import { usePathname } from 'next/navigation';
 
 interface CustomTabNavProps {
-  menus: Menu[];
+  tabs: Tab[];
+  className?: string;
 }
 
-type Menu = {
-  name: string;
-  link: string;
+type Tab = {
+  href: string;
+  label: string;
 };
 
-export default function CustomTabNav({ menus }: CustomTabNavProps) {
+export default function CustomTabNav({ tabs, className }: CustomTabNavProps) {
+  const currentPath = usePathname();
+  const isActive = (targetPath: string) => {
+    return currentPath.includes(targetPath);
+  };
+
   return (
-    <TabNav.Root>
-      {menus.map((menu: Menu) => {
+    <TabNav.Root className={cn(styles.container)}>
+      {tabs.map((tab: Tab) => {
         return (
-          <TabNav.Link href={menu.link} key={menu.name}>
-            menu.name
+          <TabNav.Link className={styles.tab} href={tab.href} key={tab.label} active={isActive(tab.href)}>
+            {tab.label}
           </TabNav.Link>
         );
       })}

--- a/src/components/TabNav/TabNav.tsx
+++ b/src/components/TabNav/TabNav.tsx
@@ -1,0 +1,25 @@
+import { TabNav } from '@radix-ui/themes';
+import styles from './TabNav.module.scss.module.scss';
+
+interface CustomTabNavProps {
+  menus: Menu[];
+}
+
+type Menu = {
+  name: string;
+  link: string;
+};
+
+export default function CustomTabNav({ menus }: CustomTabNavProps) {
+  return (
+    <TabNav.Root>
+      {menus.map((menu: Menu) => {
+        return (
+          <TabNav.Link href={menu.link} key={menu.name}>
+            menu.name
+          </TabNav.Link>
+        );
+      })}
+    </TabNav.Root>
+  );
+}

--- a/src/components/TabNav/index.ts
+++ b/src/components/TabNav/index.ts
@@ -1,0 +1,1 @@
+export { default as TabNav } from './TabNav';


### PR DESCRIPTION
### #️⃣반영 브랜치

- feat/#29 -> main, close #29

## 📝작업 내용

- TabNav 컴포넌트 작업
- 리포트 페이지에 적용

### 스크린샷 (선택)

- active 밑줄 제외 완료했습니다.

![image](https://github.com/user-attachments/assets/153d7a07-5a72-4b59-94cf-fb1003ec5f0a)

- radix 기본 밑줄 사용하려고 하면 글자 바로 밑에 생겨버립니다.
  - radix 컴포넌트 자체 내에서 padding을 줄 수 있는 설정이 있을까요..?

![image](https://github.com/user-attachments/assets/1fd533a6-45e6-4d9f-9a20-e49fe7358ea5)

- 제 미천한 css 실력으론 해당 이슈 해결하다가 한 세월 걸릴 것 같아 먼저 PR 올립니다.
