### PR TITLE
feat: 홈 바텀 시트 터치 액션 동작 안되는 문제 해결 및 회고 페이지 라우팅 추가

### DIFF
--- a/src/app/(route)/(home)/components/Drawer/Drawer.module.scss
+++ b/src/app/(route)/(home)/components/Drawer/Drawer.module.scss
@@ -23,6 +23,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  touch-action: auto;
   .info {
     margin-top: 12px;
     height: 100%;

--- a/src/app/(route)/(home)/components/Drawer/Drawer.tsx
+++ b/src/app/(route)/(home)/components/Drawer/Drawer.tsx
@@ -15,7 +15,7 @@ interface DrawerProps {
   setIsOpen: (value: boolean) => void;
 }
 export default function Drawer({ isOpen, setIsOpen, children }: PropsWithChildren<DrawerProps>) {
-  const animateState = isOpen ? 'visible' : 'hidden';
+  const animateState = isOpen ? 'hidden' : 'visible';
   const dragControls = useDragControls();
 
   const onDragEnd = (event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
@@ -26,7 +26,7 @@ export default function Drawer({ isOpen, setIsOpen, children }: PropsWithChildre
     const isOverThreshold = isOverOffsetThreshold || isOverDeltaThreshold;
     if (!isOverThreshold) return;
     const newIsOpened = info.offset.y >= 0;
-    setIsOpen(newIsOpened);
+    setIsOpen(!newIsOpened);
   };
   return (
     <motion.div
@@ -47,7 +47,7 @@ export default function Drawer({ isOpen, setIsOpen, children }: PropsWithChildre
     >
       <div className={styles.layout}>
         <motion.div onPointerDown={(e) => dragControls.start(e)}>
-          <DrawerHandle isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
+          <DrawerHandle isOpen={!isOpen} onClick={() => setIsOpen(!isOpen)} />
         </motion.div>
         {children}
       </div>

--- a/src/app/(route)/(home)/components/Page/Content.tsx
+++ b/src/app/(route)/(home)/components/Page/Content.tsx
@@ -48,7 +48,7 @@ export default function HomeContent() {
     if (getLockState(day) === 'disabled' && day > (data?.nextSurveyIndex ?? 0)) {
       showToast('하루에 한 회차씩 답변할 수 있어요');
     }
-    if (getLockState(day) === 'completed') {
+    if (getLockState(day) === 'completed' || getLockState(day) === 'completedToday') {
       routes.push(`${ROUTES.reportQuestions}&focus=${day}`);
     }
   };

--- a/src/app/(route)/(home)/components/Page/Content.tsx
+++ b/src/app/(route)/(home)/components/Page/Content.tsx
@@ -18,7 +18,7 @@ import styles from './Page.module.scss';
 
 export default function HomeContent() {
   const routes = useRouter();
-  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const { data } = useGetSurvey();
   const { showToast } = useToast();
   const daysArr = Array.from({ length: 15 }, (_, i) => i + 1);
@@ -77,7 +77,7 @@ export default function HomeContent() {
                     onClick={() => onClickBtn(day)}
                   />
                 ))}
-                {!isOpen &&
+                {isOpen &&
                   daysArr
                     .slice(5)
                     .map((day) => (

--- a/src/app/(route)/(home)/components/Page/Page.module.scss
+++ b/src/app/(route)/(home)/components/Page/Page.module.scss
@@ -4,7 +4,6 @@
   height: 100vh;
   background-color: #f8f8fa;
   overflow: hidden;
-  touch-action: none;
 }
 
 .container {
@@ -26,6 +25,7 @@
     line-height: 130%;
     white-space: pre-line;
   }
+  touch-action: none;
 }
 
 .character {
@@ -36,6 +36,7 @@
   transform: translateX(-50%);
   z-index: 1;
   height: calc(100% - 29.375rem);
+  touch-action: none;
 }
 
 .wrapper {

--- a/src/app/(route)/(home)/components/Page/Page.tsx
+++ b/src/app/(route)/(home)/components/Page/Page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import HomeContent from './Content';
 import styles from './Page.module.scss';
 import HomeTitle from './Title';

--- a/src/app/(route)/game/[bundleId]/components/GameBottomSheet/GameBottomSheet.module.scss
+++ b/src/app/(route)/game/[bundleId]/components/GameBottomSheet/GameBottomSheet.module.scss
@@ -8,3 +8,6 @@
     width: 50%;
   }
 }
+.textField {
+  color: $black;
+}

--- a/src/app/(route)/report/components/QuestionsTab/QuestionsTab.module.scss
+++ b/src/app/(route)/report/components/QuestionsTab/QuestionsTab.module.scss
@@ -8,3 +8,9 @@
 .card {
   margin: 0.5rem;
 }
+
+.loading {
+  width: 100%;
+  margin-top: 100px;
+  @include flex-center-column;
+}

--- a/src/app/(route)/report/components/QuestionsTab/QuestionsTab.tsx
+++ b/src/app/(route)/report/components/QuestionsTab/QuestionsTab.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { Skeleton } from '@radix-ui/themes';
 
 import { Card } from '@/components/Card';
+import { LottieAnimation } from '@/components/LottieAnimation';
 import { useGetSubmissions } from '@/query-hooks/useSurvey';
 
 import { EmptyTab } from '../EmptyTab';
@@ -28,6 +29,13 @@ export default function QuestionsTab({ bundleId }: { bundleId: number }) {
 
   if (submissionData.surveyRecords.length === 0 && !isLoading) {
     return <EmptyTab title={'아직 작성하신 회고가 없어요'} subTitle={'가치관 질문에 회고를 작성해보세요.'} />;
+  }
+  if (!submissionData.surveyRecords || isLoading) {
+    return (
+      <div className={styles.loading}>
+        <LottieAnimation type="loading" width="200px" height="200px" />
+      </div>
+    );
   }
 
   return (

--- a/src/app/(route)/report/components/ReportClientPage/ReportClientPage.tsx
+++ b/src/app/(route)/report/components/ReportClientPage/ReportClientPage.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-import { LottieAnimation } from '@/components/LottieAnimation';
 import { Tabs } from '@/components/Tabs';
 import { ROUTES } from '@/constants';
 import { useGetCharacters } from '@/query-hooks/useCharacter';
@@ -59,7 +58,7 @@ export default function ReportClientPage({ bundleId, characterId }: ReportProps)
   }, [character]);
 
   if (isLoading || selectCharacter === null) {
-    return <LottieAnimation type="loading" width="200px" height="200px" />;
+    return;
   }
 
   const onSelectCharacter = (character: CharacterItem) => {


### PR DESCRIPTION
### #️⃣반영 브랜치

refactor/home

## 📝작업 내용
- [x] 홈 바텀 시트 터치 액션 동작 안되는 문제 해결
- [x] 오늘 진행한 게임 -> 회고 페이지로 라우팅 추가
- [x] textfield 텍스트 컬러 추가 
- [x] 회고 api loading 상태 처리


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
